### PR TITLE
Relax bundler dependency

### DIFF
--- a/bundler-grep.gemspec
+++ b/bundler-grep.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", "~> 1.13"
+  spec.add_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Bundler 2.0 has been released.

How would you feel relaxing dependency with it so users can bundle this gem by bundler 2 or more?

Note:
In order to ensure and guarantee compatibility with bundler 1.x, we might want to add some tests for 1.x along with 2.x.